### PR TITLE
chore: require node 18 and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This is a simple API server providing with ability to easily create
 JSON API servers. Accepts also calls in www-form-urlencoded form
 and treats them identically to flat JSON key-value structure.
 
+Requires Node.js 18 or newer.
+
 ```
 const ApiSrv = require('tr-apisrv');
 

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
     "name": "tr-apisrv",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "A simple asynchronous API server class",
     "main": "index.js",
     "scripts": {
         "test": "node ./test/test.js"
     },
     "engines": {
-        "node": ">=10.0.0"
+        "node": ">=18.0.0"
     },
     "dependencies": {
     },


### PR DESCRIPTION
## Summary
- require Node.js 18 or newer in package.json
- bump package version to 0.3.0 for breaking compatibility change
- document Node 18 requirement in README

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c67ac2c7a88323bd81889ebc8c4706