### PR TITLE
Prevent logging success for unauthorized upgrades

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,23 +86,25 @@ var ApiSrv = function(opts) {
 		r.req = req;
 		return (Promise.resolve(this.authCallback(r))
 				.then(function(ret) {
-					if (ret) {
-						r.head = head;
-						r.s = s;
-						return opts.upgradeCallback(r);
-					} else {
-						s.destroy();
-						s = undefined;
-					}
-				}.bind(this))
-				.then(function(ret) {
-					if (ret !== false) {
-						if (this.debug) {
-							console.log('Upgrade successfully processed (resource :' + r.url + ').');
-						}
-					}
-				}.bind(this))
-				.catch(function(e) {
+                                        if (ret) {
+                                                r.head = head;
+                                                r.s = s;
+                                                return opts.upgradeCallback(r);
+                                        } else {
+                                                s.destroy();
+                                                s = undefined;
+                                               return false;
+                                       }
+                               }.bind(this))
+                               .then(function(ret) {
+                                       if (ret) {
+                                               if (this.debug) {
+                                                       console.log('Upgrade successfully processed (resource :' + r.url + ').');
+                                               }
+                                       }
+                                       return ret;
+                               }.bind(this))
+                               .catch(function(e) {
 					if (s) {
 						try {
 							s.destroy();

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,53 @@
 'use strict';
-const x = require('../index');
-process.exit(0);
+
+const ApiSrv = require('../index');
+const http = require('http');
+
+async function unauthorizedUpgrade() {
+    const logs = [];
+    const origLog = console.log;
+    console.log = (msg) => logs.push(msg);
+
+    const srv = new ApiSrv({
+        port: 12345,
+        callback: () => {},
+        authCallback: () => false,
+        upgradeCallback: () => true,
+        debug: true
+    });
+
+    try {
+        await new Promise((resolve, reject) => {
+            const req = http.request({
+                port: 12345,
+                hostname: '127.0.0.1',
+                headers: {
+                    Connection: 'Upgrade',
+                    Upgrade: 'websocket'
+                }
+            });
+            req.on('upgrade', (res, socket, head) => {
+                socket.destroy();
+                resolve();
+            });
+            req.on('error', resolve);
+            req.end();
+        });
+        await new Promise(r => setTimeout(r, 50));
+    } finally {
+        console.log = origLog;
+        srv.server.close();
+    }
+
+    if (logs.some(l => l.includes('Upgrade successfully processed'))) {
+        throw new Error('Unauthorized upgrade logged success');
+    }
+}
+
+unauthorizedUpgrade()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error(e);
+        process.exit(1);
+    });
+


### PR DESCRIPTION
## Summary
- Return `false` after destroying unauthorized upgrade sockets so the promise chain reflects failure
- Log upgrade success only when the previous step returns a truthy value and propagate the result
- Add a test ensuring unauthorized upgrades do not report success

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c67bf545888323b1f16c28ab1c99e7