### PR TITLE
Align server timeouts with bodyReadTimeoutMs

### DIFF
--- a/index.js
+++ b/index.js
@@ -305,7 +305,8 @@ var ApiSrv = function(opts) {
 		console.log('Unable to start HTTP server');
 		process.exit(1);
 	});
-	this.server.headersTimeout = 2000;
+	this.server.headersTimeout = this.bodyReadTimeoutMs;
+	this.server.requestTimeout = this.bodyReadTimeoutMs + 1;
 	this.server.listen(this.port, this.address);
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,29 @@
 'use strict';
-const x = require('../index');
-process.exit(0);
+
+const assert = require('assert');
+const ApiSrv = require('../index');
+
+const timeout = 2500;
+
+const srv = new ApiSrv({
+    port: 8000,
+    address: '127.0.0.1',
+    bodyReadTimeoutMs: timeout,
+    callback: function () {}
+});
+
+srv.server.on('listening', function () {
+    try {
+        assert.strictEqual(srv.server.headersTimeout, timeout);
+        assert.strictEqual(srv.server.requestTimeout, timeout + 1);
+    } catch (e) {
+        console.error(e);
+        return srv.server.close(function () {
+            process.exit(1);
+        });
+    }
+    srv.server.close(function () {
+        process.exit(0);
+    });
+});
+


### PR DESCRIPTION
## Summary
- Use configurable `bodyReadTimeoutMs` when setting server's `headersTimeout`
- Set `requestTimeout` based on `bodyReadTimeoutMs + 1`
- Add test ensuring custom timeout values are applied to the server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c67bf3a9848323b245aad4da949fe8