### PR TITLE
feat: add request body size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ var srv = new ApiSrv({ port: 8808,
                        authCallback: authCb,
                        prettyPrintJsonResponses: true,
                        bodyReadTimeoutMs: 5000,
+                       maxBodySize: 1024 * 1024,
                        debug: true });
 
 async function authCb(r) {
@@ -26,6 +27,9 @@ async function cb(r) {
     r.jsonResponse(r, 200);
 }
 ```
+
+`maxBodySize` limits the size of accepted request bodies in bytes. Requests exceeding
+the limit are terminated with HTTP status 413. The default limit is 1 MiB.
 
 Author
 ======

--- a/index.js
+++ b/index.js
@@ -66,6 +66,15 @@ var ApiSrv = function(opts) {
 	} else {
 		this.bodyReadTimeoutMs = 2 * 1000;
 	}
+	if ((opts.maxBodySize !== undefined) && (opts.maxBodySize !== null)) {
+		if (Number.isSafeInteger(opts.maxBodySize) && (opts.maxBodySize >= 0)) {
+			this.maxBodySize = opts.maxBodySize;
+		} else {
+			throw new Error('Bad maxBodySize for ApiSrv constructor');
+		}
+	} else {
+		this.maxBodySize = 1024 * 1024;
+	}
 	srvOpts.headersTimeout = this.bodyReadTimeoutMs;
 	srvOpts.requestTimeout = this.bodyReadTimeoutMs + 1;
 
@@ -115,10 +124,24 @@ var ApiSrv = function(opts) {
 				}.bind(this)));
 	}.bind(this);
 	var requestCb = function(req, res) {
-		var completed = false, body = Buffer.alloc(0), r = {}, timeout;
+		var completed = false, body = Buffer.alloc(0), r = {}, timeout, bodySize = 0;
 		var contentType, contentTypeArgs;
 		var dataCb = function(data) {
 			if (completed) {
+				return;
+			}
+			bodySize += data.length;
+			if (this.maxBodySize && (bodySize > this.maxBodySize)) {
+				completed = true;
+				if (timeout) {
+					clearTimeout(timeout);
+					timeout = undefined;
+				}
+				error(res, 413, 'Request body too large.');
+				try {
+					req.destroy();
+				} catch (ignored) {
+				}
 				return;
 			}
 			body = Buffer.concat( [ body, data ] );


### PR DESCRIPTION
## Summary
- allow configuring a maximum request body size via `maxBodySize`
- abort data processing with HTTP 413 when incoming payload exceeds the limit
- document `maxBodySize` option and default 1 MiB limit

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c67be8aa8c8323a4a51f9433baa82e