### PR TITLE
Respect configurable body read timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -326,12 +326,13 @@ var ApiSrv = function(opts) {
 	if (this.upgradeCallback) {
 		this.server.on('upgrade', upgradeCb);
 	}
-	this.server.on('error', function(e) {
-		console.log('Unable to start HTTP server');
-		process.exit(1);
-	});
-	this.server.headersTimeout = 2000;
-	this.server.listen(this.port, this.address);
+        this.server.on('error', function(e) {
+                console.log('Unable to start HTTP server');
+                process.exit(1);
+        });
+        this.server.headersTimeout = this.bodyReadTimeoutMs;
+        this.server.requestTimeout = this.bodyReadTimeoutMs + 1;
+        this.server.listen(this.port, this.address);
 };
 
 module.exports = ApiSrv;

--- a/test/test.js
+++ b/test/test.js
@@ -44,7 +44,31 @@ async function unauthorizedUpgrade() {
     }
 }
 
-unauthorizedUpgrade()
+async function customTimeouts() {
+    const srv = new ApiSrv({
+        port: 12346,
+        bodyReadTimeoutMs: 1234,
+        callback: () => {}
+    });
+
+    try {
+        if (srv.server.headersTimeout !== 1234) {
+            throw new Error('headersTimeout not set');
+        }
+        if (srv.server.requestTimeout !== 1235) {
+            throw new Error('requestTimeout not set');
+        }
+    } finally {
+        srv.server.close();
+    }
+}
+
+async function main() {
+    await unauthorizedUpgrade();
+    await customTimeouts();
+}
+
+main()
     .then(() => process.exit(0))
     .catch((e) => {
         console.error(e);


### PR DESCRIPTION
## Summary
- honor `bodyReadTimeoutMs` when setting server timeouts
- test that custom timeouts are applied

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6782327648323b142460ca617ac73