### PR TITLE
Add server close helper and cycle test

### DIFF
--- a/index.js
+++ b/index.js
@@ -346,4 +346,16 @@ var ApiSrv = function(opts) {
         this.server.listen(this.port, this.address);
 };
 
+ApiSrv.prototype.close = function() {
+        return new Promise((resolve, reject) => {
+                this.server.close((err) => {
+                        if (err) {
+                                reject(err);
+                        } else {
+                                resolve();
+                        }
+                });
+        });
+};
+
 module.exports = ApiSrv;

--- a/test/test.js
+++ b/test/test.js
@@ -133,11 +133,23 @@ async function badCharset() {
     }
 }
 
+async function startStopCycles() {
+    for (let i = 0; i < 2; i++) {
+        const srv = new ApiSrv({
+            port: 12349,
+            callback: () => {}
+        });
+        await new Promise(resolve => srv.server.on('listening', resolve));
+        await srv.close();
+    }
+}
+
 async function main() {
     await unauthorizedUpgrade();
     await customTimeouts();
     await queryParsing();
     await badCharset();
+    await startStopCycles();
 }
 
 main()


### PR DESCRIPTION
## Summary
- add `close` instance method returning a promise wrapper around `server.close`
- add test to verify API server can start and stop repeatedly on the same port

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6829ced3c8323b083cca21f9fcffd