### PR TITLE
Add comprehensive API server tests using node:test

### DIFF
--- a/index.js
+++ b/index.js
@@ -358,4 +358,7 @@ ApiSrv.prototype.close = function() {
         });
 };
 
+// Backward compatible shutdown helper
+ApiSrv.prototype.shutdown = ApiSrv.prototype.close;
+
 module.exports = ApiSrv;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "A simple asynchronous API server class",
     "main": "index.js",
     "scripts": {
-        "test": "node ./test/test.js"
+        "test": "node --test test/test.js"
     },
     "engines": {
         "node": ">=18.0.0"


### PR DESCRIPTION
## Summary
- Replace custom script with node:test suite covering GET, POST, PUT and DELETE requests
- Verify authentication callbacks, request timeouts and shutdown helper
- Expose `shutdown` alias for server close and use node's built-in test runner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c683366b0483239f6753157016e6fd