### PR TITLE
docs: add handler examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,61 @@ async function cb(r) {
 }
 ```
 
+Examples
+========
+
+GET handler with path parameter
+-------------------------------
+
+```javascript
+async function cb(r) {
+    if (r.method === 'GET') {
+        // Match URL like /user/123 and capture the id
+        const m = r.url.match(/^\/user\/([^/]+)$/);
+        if (m) {
+            const id = m[1];
+            // r.params contains parsed query string values
+            return r.jsonResponse({ id, params: r.params });
+        }
+    }
+}
+```
+
+POST handler with JSON body
+---------------------------
+
+```javascript
+async function cb(r) {
+    if (r.method === 'POST') {
+        // Match URL like /user/123 and capture the id
+        const m = r.url.match(/^\/user\/([^/]+)$/);
+        if (m) {
+            const id = m[1];
+            // Body is already parsed into r.params
+            return r.jsonResponse({ id, received: r.params });
+        }
+    }
+}
+```
+
+Non‑JSON response
+-----------------
+
+Sometimes a handler may need to send a plain text or other custom response.
+The underlying `http.ServerResponse` is available as `r.res`:
+
+```javascript
+async function cb(r) {
+    if (r.url === '/plaintext') {
+        r.res.writeHead(200, { 'Content-Type': 'text/plain' });
+        r.res.end('ok');
+        return;
+    }
+    // default JSON response
+    return r.jsonResponse({ ok: true });
+}
+```
+
 `maxBodySize` limits the size of accepted request bodies in bytes. Requests exceeding
 the limit are terminated with HTTP status 413. The default limit is 1 MiB.
 


### PR DESCRIPTION
## Summary
- document typical GET and POST handler patterns including URL parameters
- show how to send custom non-JSON responses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c68b38cf088323a9fd08956dcd15f8