### PR TITLE
Add requestHandlers routing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,20 @@ Method keys in `requestHandlers` should be uppercase (`GET`, `POST`, `PUT`, `DEL
 
 * **Literal segments** – `/users/list` matches exactly that path.
 * **Single-segment captures** – `{name}` captures one path component and makes it
-  available as a string. Example: `/users/{userId}` matches `/users/123` and sets
-  `request.pathParams.userId === '123'`.
+  available as a string. Capture names must match the regular expression
+  `/^[A-Za-z_][A-Za-z0-9_]*$/`. Example: `/users/{userId}` matches `/users/123`
+  and sets `request.pathParams.userId === '123'`.
 * **Multi-segment captures** – `[name]` captures one or more consecutive
-  segments and exposes them as an array of strings. Example: `/files/[path]`
-  matches `/files/a/b/c` and sets `request.pathParams.path === ['a','b','c']`.
+  segments and exposes them as an array of strings. Names follow the same
+  pattern restriction as `{name}`. Arrays match 1–32 segments by default, and
+  you can provide explicit bounds with `[name:min]` (exact length) or
+  `[name:min:max]` (inclusive range). Examples:
+  * `/example/path/[MyArray]` matches 1 to 32 segments.
+  * `/example/path/[MyArray:4]` matches exactly four segments.
+  * `/example/path/[MyArray:2:12]` matches two to twelve segments.
+  * `/example/path/[MyArray:10:50]` matches ten to fifty segments, allowing
+    larger maxima than the default. The upper bound is always finite—either the
+    default 32 or the explicit maximum you declare.
 * Captures can be combined with literals, e.g. `/{cmd}/[args]/{tail}`. When
   combined, `[args]` consumes all necessary segments so the remaining template
   still matches.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ can be disabled by constructing the server with `rejectDangerousPaths: false`.
 
 Values extracted from the path take precedence over query string parameters,
 which in turn override values parsed from the request body. The server prints a
-warning whenever a later source overrides an earlier value.
+warning whenever a later source overrides an earlier value. Individual sources
+are always available as `r.pathParams`, `r.urlParams`, and `r.bodyParams`
+respectively when handling a request.
 
 Examples
 ========
@@ -104,8 +106,8 @@ async function cb(r) {
         const m = r.url.match(/^\/user\/([^/]+)$/);
         if (m) {
             const id = m[1];
-            // r.params contains parsed query string values
-            return r.jsonResponse({ id, params: r.params });
+            // r.urlParams contains parsed query string values
+            return r.jsonResponse({ id, params: r.params, query: r.urlParams });
         }
     }
 }
@@ -121,8 +123,8 @@ async function cb(r) {
         const m = r.url.match(/^\/user\/([^/]+)$/);
         if (m) {
             const id = m[1];
-            // Body is already parsed into r.params
-            return r.jsonResponse({ id, received: r.params });
+            // Body is already parsed into r.params and r.bodyParams
+            return r.jsonResponse({ id, received: r.params, body: r.bodyParams });
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ merged into `r.params`:
   components (for example `/{cmd}/[zap]/{bar}/{pup}`), it captures all segments
   required to allow the remainder of the template to match.
 
+Trailing slashes in handler definitions are significant: if a template ends
+with `/`, it matches only when the request path also ends with `/`. Templates
+without a trailing slash match both `/foo` and `/foo/`.
+
 Values extracted from the path take precedence over query string parameters,
 which in turn override values parsed from the request body. The server prints a
 warning whenever a later source overrides an earlier value.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ var srv = new ApiSrv({ port: 8808,
                        callback: cb,
                        authCallback: authCb,
                        prettyPrintJsonResponses: true,
+                       rejectDangerousPaths: true,
                        bodyReadTimeoutMs: 5000,
                        maxBodySize: 1024 * 1024,
                        debug: true });
@@ -80,6 +81,11 @@ merged into `r.params`:
 Trailing slashes in handler definitions are significant: if a template ends
 with `/`, it matches only when the request path also ends with `/`. Templates
 without a trailing slash match both `/foo` and `/foo/`.
+
+For safety, `ApiSrv` rejects paths that contain empty segments (`//`) or dot
+segments (`/.` or `/..`). The rejection happens before authentication or
+handlers run and responds with HTTP 400. This check is enabled by default and
+can be disabled by constructing the server with `rejectDangerousPaths: false`.
 
 Values extracted from the path take precedence over query string parameters,
 which in turn override values parsed from the request body. The server prints a

--- a/README.md
+++ b/README.md
@@ -67,6 +67,41 @@ srv.requestHandleDelete('GET', '/foo/bar');
 srv.requestHandleDelete('*', '/foo/bar');
 ```
 
+Each handler entry can be either a callback function or an object with a
+`callback` property and an optional `options` object:
+
+```javascript
+const srv = new ApiSrv({
+    port: 8808,
+    requestHandlers: {
+        GET: {
+            '/user/{userId}': {
+                callback: getUser,
+                options: {
+                    pathParamsValidator: (params) => ({ userId: Number(params.userId) }),
+                    urlParamsValidator: async (query) => ({ page: Number(query.page ?? 1) }),
+                    paramsValidator: (params) => ({ ...params, validated: true })
+                }
+            }
+        }
+    }
+});
+```
+
+The supported handler options are:
+
+* `pathParamsValidator`: validate and optionally transform `r.pathParams`.
+* `urlParamsValidator`: validate and optionally transform `r.urlParams`.
+* `bodyParamsValidator`: validate and optionally transform `r.bodyParams`.
+* `paramsValidator`: validate the merged `r.params` before the handler runs.
+* `ignoreUrlParams`: when `true`, the query string is ignored (`r.urlParams`
+  is left undefined and `urlParamsValidator` is not called).
+
+Validator callbacks may be synchronous or asynchronous. They must return the
+new object to use in place of the original input and may throw to signal a bad
+request. The same `options` object can be supplied when adding handlers at
+runtime with `srv.requestHandleAdd(method, path, callback, options)`.
+
 Path templates support dynamic components that are automatically decoded and
 merged into `r.params`:
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Handlers receive an object that wraps the underlying `http.IncomingMessage` and
 | `res` | The raw `http.ServerResponse`. |
 | `headers` | Request headers as received. |
 | `jsonResponse(data, statusCode?, excludeNoCacheHeaders?)` | Serializes JSON responses and sets default no-cache headers unless `excludeNoCacheHeaders` is `true`. |
+| `errorResponse(statusCode, detail?)` | Sends a JSON error using canonical HTTP status text. For `400 Bad Request`, the optional detail is appended in parentheses. |
 | `params` | Merged view of all parameters (body < query < path precedence). |
 | `pathParams` | Parameters parsed from the matched path template. |
 | `urlParams` | Parsed query parameters (unless suppressed). Arrays are preserved when the query repeats a key. |

--- a/README.md
+++ b/README.md
@@ -28,6 +28,44 @@ async function cb(r) {
 }
 ```
 
+Request handler configuration
+-----------------------------
+
+Specific handlers can be declared per HTTP method by supplying the
+`requestHandlers` option. Handlers defined this way take precedence over the
+top-level `callback`. If no handler matches a request and no fallback callback
+is provided, the server responds with a JSON error message (404 when the path is
+unknown, 405 when another method is registered for the same path).
+
+```javascript
+const srv = new ApiSrv({
+    port: 8808,
+    requestHandlers: {
+        GET: {
+            '/': rootCb,
+            '/user': userCb,
+            '/user/{userId}': userCb
+        },
+        POST: {
+            '/user/{userId}': updateUserCb
+        },
+        PUT: {
+            '/media/{mediaId}': uploadMediaCb
+        },
+        DELETE: {
+            '/user/{userId}': deleteUserCb
+        }
+    },
+    callback: fallbackCb // optional fallback when no requestHandlers match
+});
+
+// requestHandlers can be modified at runtime
+srv.requestHandleAdd('GET', '/foo/bar', fooBarCb);
+srv.requestHandleAdd('POST', '/foo/bar', fooBarCb);
+srv.requestHandleDelete('GET', '/foo/bar');
+srv.requestHandleDelete('*', '/foo/bar');
+```
+
 Examples
 ========
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ srv.requestHandleDelete('GET', '/foo/bar');
 srv.requestHandleDelete('*', '/foo/bar');
 ```
 
+Path templates support dynamic components that are automatically decoded and
+merged into `r.params`:
+
+* `{variable}` matches exactly one path segment and assigns the decoded value to
+  `r.params.variable` (for example `/user/{userId}` captures the identifier from
+  `/user/123`).
+* `[variable]` matches one or more consecutive segments and assigns an array of
+  decoded values to `r.params.variable`. When used between literal or `{}`
+  components (for example `/{cmd}/[zap]/{bar}/{pup}`), it captures all segments
+  required to allow the remainder of the template to match.
+
+Values extracted from the path take precedence over query string parameters,
+which in turn override values parsed from the request body. The server prints a
+warning whenever a later source overrides an earlier value.
+
 Examples
 ========
 

--- a/index.js
+++ b/index.js
@@ -150,7 +150,7 @@ function compilePathTemplate(path) {
 }
 
 function matchCompiledPath(compiled, pathInfo) {
-    if (compiled.hasTrailingSlash !== pathInfo.hasTrailingSlash) {
+    if (compiled.hasTrailingSlash && !pathInfo.hasTrailingSlash) {
         return null;
     }
     if (pathInfo.segments.length < compiled.minSegments) {
@@ -284,9 +284,16 @@ function findMatchInStore(store, path) {
     if (!store) {
         return null;
     }
-    const exact = store.exact.get(path);
+    let exact = store.exact.get(path);
     if (exact) {
         return { handler: exact.handler, params: {} };
+    }
+    if ((path.length > 1) && path.endsWith('/')) {
+        const trimmed = path.slice(0, -1);
+        exact = store.exact.get(trimmed);
+        if (exact && !exact.hasTrailingSlash) {
+            return { handler: exact.handler, params: {} };
+        }
     }
     const pathInfo = describePath(path);
     for (const entry of store.dynamic.values()) {

--- a/index.js
+++ b/index.js
@@ -687,6 +687,9 @@ class ApiSrv {
                 }
                 res.end();
             };
+            r.errorResponse = (code, detail) => {
+                return error(res, code, detail);
+            };
             try {
                 let handlerEntry = this.#matchRequestHandler(r.method, r.url);
                 let handler = handlerEntry ? handlerEntry.handler : undefined;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tr-apisrv",
-    "version": "2.0.2",
+    "version": "2.1.0",
     "description": "A simple asynchronous API server class",
     "main": "index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tr-apisrv",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "description": "A simple asynchronous API server class",
     "main": "index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tr-apisrv",
-    "version": "2.1.0",
+    "version": "2.0.0",
     "description": "A simple asynchronous API server class",
     "main": "index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tr-apisrv",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "A simple asynchronous API server class",
     "main": "index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tr-apisrv",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "description": "A simple asynchronous API server class",
     "main": "index.js",
     "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -185,7 +185,9 @@ test('returns 404 when no handler matches and callback missing', async () => {
         const res = await httpRequest(port, { method: 'GET', path: '/bar' });
         assert.strictEqual(res.status, 404);
         assert.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8');
-        assert.deepStrictEqual(JSON.parse(res.data), { message: 'Not Found', code: 404 });
+        const body = JSON.parse(res.data);
+        assert.strictEqual(body.code, 404);
+        assert.strictEqual(body.message, 'Not Found');
     } finally {
         await srv.shutdown();
     }
@@ -210,7 +212,9 @@ test('returns 405 when path matches other method and callback missing', async ()
         });
         assert.strictEqual(res.status, 405);
         assert.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8');
-        assert.deepStrictEqual(JSON.parse(res.data), { message: 'Method Not Allowed', code: 405 });
+        const body = JSON.parse(res.data);
+        assert.strictEqual(body.code, 405);
+        assert.strictEqual(body.message, 'Method Not Allowed');
     } finally {
         await srv.shutdown();
     }
@@ -238,7 +242,9 @@ test('requestHandleAdd and requestHandleDelete modify handlers at runtime', asyn
         srv.requestHandleDelete('GET', '/dynamic');
         res = await httpRequest(port, { method: 'GET', path: '/dynamic' });
         assert.strictEqual(res.status, 405);
-        assert.deepStrictEqual(JSON.parse(res.data), { message: 'Method Not Allowed', code: 405 });
+        let body = JSON.parse(res.data);
+        assert.strictEqual(body.code, 405);
+        assert.strictEqual(body.message, 'Method Not Allowed');
 
         srv.requestHandleDelete('*', '/dynamic');
         res = await httpRequest(port, {
@@ -248,7 +254,9 @@ test('requestHandleAdd and requestHandleDelete modify handlers at runtime', asyn
             body: JSON.stringify({})
         });
         assert.strictEqual(res.status, 404);
-        assert.deepStrictEqual(JSON.parse(res.data), { message: 'Not Found', code: 404 });
+        body = JSON.parse(res.data);
+        assert.strictEqual(body.code, 404);
+        assert.strictEqual(body.message, 'Not Found');
     } finally {
         await srv.shutdown();
     }
@@ -316,7 +324,9 @@ test('body read timeout returns 408', async () => {
             req.write('123'); // intentionally never calling end to trigger timeout
         });
         assert.strictEqual(res.status, 408);
-        assert.strictEqual(res.data, 'Timeout occured while reading the request data.\n');
+        const body = JSON.parse(res.data);
+        assert.strictEqual(body.code, 408);
+        assert.strictEqual(body.message, 'Request Timeout');
     } finally {
         await srv.shutdown();
     }

--- a/test/test.js
+++ b/test/test.js
@@ -45,12 +45,24 @@ test('handles GET requests', async () => {
     const port = 12350;
     const srv = new ApiSrv({
         port,
-        callback: (r) => r.jsonResponse({ method: r.method, params: r.params })
+        callback: (r) => r.jsonResponse({
+            method: r.method,
+            params: r.params,
+            pathParams: r.pathParams,
+            urlParams: r.urlParams,
+            bodyParams: r.bodyParams
+        })
     });
     try {
         const res = await httpRequest(port, { method: 'GET', path: '/?a=1' });
         assert.strictEqual(res.status, 200);
-        assert.deepStrictEqual(JSON.parse(res.data), { method: 'GET', params: { a: '1' } });
+        assert.deepStrictEqual(JSON.parse(res.data), {
+            method: 'GET',
+            params: { a: '1' },
+            pathParams: {},
+            urlParams: { a: '1' },
+            bodyParams: {}
+        });
     } finally {
         await srv.shutdown();
     }
@@ -60,7 +72,13 @@ test('handles POST requests', async () => {
     const port = 12351;
     const srv = new ApiSrv({
         port,
-        callback: (r) => r.jsonResponse({ method: r.method, params: r.params })
+        callback: (r) => r.jsonResponse({
+            method: r.method,
+            params: r.params,
+            pathParams: r.pathParams,
+            urlParams: r.urlParams,
+            bodyParams: r.bodyParams
+        })
     });
     try {
         const res = await httpRequest(port, {
@@ -70,7 +88,13 @@ test('handles POST requests', async () => {
             body: JSON.stringify({ a: 1 })
         });
         assert.strictEqual(res.status, 200);
-        assert.deepStrictEqual(JSON.parse(res.data), { method: 'POST', params: { a: 1 } });
+        assert.deepStrictEqual(JSON.parse(res.data), {
+            method: 'POST',
+            params: { a: 1 },
+            pathParams: {},
+            urlParams: {},
+            bodyParams: { a: 1 }
+        });
     } finally {
         await srv.shutdown();
     }
@@ -80,7 +104,13 @@ test('handles PUT requests', async () => {
     const port = 12352;
     const srv = new ApiSrv({
         port,
-        callback: (r) => r.jsonResponse({ method: r.method, params: r.params })
+        callback: (r) => r.jsonResponse({
+            method: r.method,
+            params: r.params,
+            pathParams: r.pathParams,
+            urlParams: r.urlParams,
+            bodyParams: r.bodyParams
+        })
     });
     try {
         const res = await httpRequest(port, {
@@ -90,7 +120,13 @@ test('handles PUT requests', async () => {
             body: 'a=1'
         });
         assert.strictEqual(res.status, 200);
-        assert.deepStrictEqual(JSON.parse(res.data), { method: 'PUT', params: { a: '1' } });
+        assert.deepStrictEqual(JSON.parse(res.data), {
+            method: 'PUT',
+            params: { a: '1' },
+            pathParams: {},
+            urlParams: {},
+            bodyParams: { a: '1' }
+        });
     } finally {
         await srv.shutdown();
     }
@@ -100,12 +136,24 @@ test('handles DELETE requests', async () => {
     const port = 12353;
     const srv = new ApiSrv({
         port,
-        callback: (r) => r.jsonResponse({ method: r.method, params: r.params })
+        callback: (r) => r.jsonResponse({
+            method: r.method,
+            params: r.params,
+            pathParams: r.pathParams,
+            urlParams: r.urlParams,
+            bodyParams: r.bodyParams
+        })
     });
     try {
         const res = await httpRequest(port, { method: 'DELETE', path: '/?a=1' });
         assert.strictEqual(res.status, 200);
-        assert.deepStrictEqual(JSON.parse(res.data), { method: 'DELETE', params: { a: '1' } });
+        assert.deepStrictEqual(JSON.parse(res.data), {
+            method: 'DELETE',
+            params: { a: '1' },
+            pathParams: {},
+            urlParams: { a: '1' },
+            bodyParams: {}
+        });
     } finally {
         await srv.shutdown();
     }
@@ -140,7 +188,13 @@ test('requestHandlers support path templates', async (t) => {
         callback: (r) => r.jsonResponse({ handled: 'callback' }),
         requestHandlers: {
             GET: {
-                '/user/{userId}': (r) => r.jsonResponse({ handled: 'requestHandlers', params: r.params })
+                '/user/{userId}': (r) => r.jsonResponse({
+                    handled: 'requestHandlers',
+                    params: r.params,
+                    pathParams: r.pathParams,
+                    urlParams: r.urlParams,
+                    bodyParams: r.bodyParams
+                })
             }
         }
     });
@@ -149,7 +203,10 @@ test('requestHandlers support path templates', async (t) => {
         assert.strictEqual(res.status, 200);
         assert.deepStrictEqual(JSON.parse(res.data), {
             handled: 'requestHandlers',
-            params: { foo: 'bar', userId: '123' }
+            params: { foo: 'bar', userId: '123' },
+            pathParams: { userId: '123' },
+            urlParams: { foo: 'bar', userId: 'query' },
+            bodyParams: {}
         });
         assert.strictEqual(warnings.length, 1);
         assert.match(warnings[0], /userId/);
@@ -214,18 +271,33 @@ test('dynamic template without trailing slash matches both forms', async () => {
         port,
         requestHandlers: {
             GET: {
-                '/user/{userId}': (r) => r.jsonResponse({ params: r.params })
+                '/user/{userId}': (r) => r.jsonResponse({
+                    params: r.params,
+                    pathParams: r.pathParams,
+                    urlParams: r.urlParams,
+                    bodyParams: r.bodyParams
+                })
             }
         }
     });
     try {
         let res = await httpRequest(port, { method: 'GET', path: '/user/abc' });
         assert.strictEqual(res.status, 200);
-        assert.deepStrictEqual(JSON.parse(res.data), { params: { userId: 'abc' } });
+        assert.deepStrictEqual(JSON.parse(res.data), {
+            params: { userId: 'abc' },
+            pathParams: { userId: 'abc' },
+            urlParams: {},
+            bodyParams: {}
+        });
 
         res = await httpRequest(port, { method: 'GET', path: '/user/abc/' });
         assert.strictEqual(res.status, 200);
-        assert.deepStrictEqual(JSON.parse(res.data), { params: { userId: 'abc' } });
+        assert.deepStrictEqual(JSON.parse(res.data), {
+            params: { userId: 'abc' },
+            pathParams: { userId: 'abc' },
+            urlParams: {},
+            bodyParams: {}
+        });
     } finally {
         await srv.shutdown();
     }
@@ -282,14 +354,17 @@ test('requestHandlers capture array segments with [variable]', async () => {
         port,
         requestHandlers: {
             GET: {
-                '/files/[pathParts]': (r) => r.jsonResponse({ params: r.params })
+                '/files/[pathParts]': (r) => r.jsonResponse({ params: r.params, pathParams: r.pathParams })
             }
         }
     });
     try {
         const res = await httpRequest(port, { method: 'GET', path: '/files/foo/bar/baz' });
         assert.strictEqual(res.status, 200);
-        assert.deepStrictEqual(JSON.parse(res.data), { params: { pathParts: ['foo', 'bar', 'baz'] } });
+        assert.deepStrictEqual(JSON.parse(res.data), {
+            params: { pathParts: ['foo', 'bar', 'baz'] },
+            pathParams: { pathParts: ['foo', 'bar', 'baz'] }
+        });
     } finally {
         await srv.shutdown();
     }
@@ -301,7 +376,7 @@ test('requestHandlers capture [variable] segments in the middle of a template', 
         port,
         requestHandlers: {
             GET: {
-                '/{cmd}/[zap]/{bar}/{pup}': (r) => r.jsonResponse({ params: r.params })
+                '/{cmd}/[zap]/{bar}/{pup}': (r) => r.jsonResponse({ params: r.params, pathParams: r.pathParams })
             }
         }
     });
@@ -310,6 +385,12 @@ test('requestHandlers capture [variable] segments in the middle of a template', 
         assert.strictEqual(res.status, 200);
         assert.deepStrictEqual(JSON.parse(res.data), {
             params: {
+                cmd: 'do',
+                zap: ['one', 'two'],
+                bar: 'three',
+                pup: 'four'
+            },
+            pathParams: {
                 cmd: 'do',
                 zap: ['one', 'two'],
                 bar: 'three',
@@ -329,7 +410,12 @@ test('path parameters override body parameters with warning', async (t) => {
         port,
         requestHandlers: {
             POST: {
-                '/user/{userId}': (r) => r.jsonResponse({ params: r.params })
+                '/user/{userId}': (r) => r.jsonResponse({
+                    params: r.params,
+                    pathParams: r.pathParams,
+                    urlParams: r.urlParams,
+                    bodyParams: r.bodyParams
+                })
             }
         }
     });
@@ -342,7 +428,10 @@ test('path parameters override body parameters with warning', async (t) => {
         });
         assert.strictEqual(res.status, 200);
         assert.deepStrictEqual(JSON.parse(res.data), {
-            params: { userId: '123', name: 'alice' }
+            params: { userId: '123', name: 'alice' },
+            pathParams: { userId: '123' },
+            urlParams: {},
+            bodyParams: { userId: 'fromBody', name: 'alice' }
         });
         assert.strictEqual(warnings.length, 1);
         assert.match(warnings[0], /userId/);


### PR DESCRIPTION
## Summary
- add optional requestHandlers configuration with method/path matching and JSON 404/405 responses when no handlers exist
- expose APIs to add or remove request handlers at runtime and update documentation
- bump package version to 2.0.0 and expand test coverage for routing behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca95185930832391fba1416dee30d7